### PR TITLE
updating template snippet for byte 2 string conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A minimal `templates/base.html` to render the content:
     <title>{{.FrontMatter.title}}</title>
 </head>
 <body>
-    {{ .Content | HTML }}
+     {{ BytesToString .Content | HTML }}
 </body>
 </html>
 ```


### PR DESCRIPTION
Adding BytesToString to the template code snippet in README 

Converts .Content into byte slice for easier template digestion 

Avoids expected string; got []uint8 templating error
